### PR TITLE
Cosmic v3 API update

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -38,7 +38,7 @@ else
     {
         string cosmic_bucket_slug = Configuration["AppSettings:COSMIC_BUCKET_SLUG"];
         string cosmic_read_key = Configuration["AppSettings:COSMIC_READ_KEY"];
-        var url = "https://api.cosmicjs.com/v1/{COSMIC_BUCKET_SLUG}/objects?pretty=true&hide_metafields=true&type=posts&read_key={COSMIC_READ_KEY}";
+        var url = "https://api.cosmicjs.com/v3/buckets/{COSMIC_BUCKET_SLUG}/objects?pretty=true&hide_metafields=true&type=posts&read_key={COSMIC_READ_KEY}";
         url = url.Replace("{COSMIC_BUCKET_SLUG}", cosmic_bucket_slug);
         url = url.Replace("{COSMIC_READ_KEY}", cosmic_read_key);
         allPosts = await Http.GetFromJsonAsync<AllPost>(url);

--- a/Pages/PostDetails.razor
+++ b/Pages/PostDetails.razor
@@ -36,7 +36,9 @@ else
     {
         string cosmic_bucket_slug = Configuration["AppSettings:COSMIC_BUCKET_SLUG"];
         string cosmic_read_key = Configuration["AppSettings:COSMIC_READ_KEY"];
-        var url = $"https://api.cosmicjs.com/v1/{cosmic_bucket_slug}/object/{Slug}?pretty=true&hide_metafields=true&read_key={cosmic_read_key}";
+        string queryParam = $"{{\"type\":\"blogs\",\"slug\":\"{Slug}\"}}";
+        string encodedQueryParam = HttpUtility.UrlEncode(queryParam);
+        var url = $"https://api.cosmicjs.com/v3/buckets/{cosmic_bucket_slug}/objects/?query={encodedQueryParam}&pretty=true&hide_metafields=true&read_key={cosmic_read_key}";
         url = url.Replace("{COSMIC_BUCKET_SLUG}", cosmic_bucket_slug);
         url = url.Replace("{COSMIC_READ_KEY}", cosmic_read_key);
         postDetails = await Http.GetFromJsonAsync<PostDetail>(url.Replace("{Slug}", Slug));


### PR DESCRIPTION
Updated project to use latest V3 API from COSMIC. 

Changes: 

- Index.razor: changed API call
- PostDetails: Changed API call and added encoded query params to match [V3 API requirement for calling a post based on slug. ](https://www.cosmicjs.com/docs/api/objects#get-a-single-object-by-slug)
